### PR TITLE
add padding to disqus comment

### DIFF
--- a/src/@narative/gatsby-theme-novela/templates/article.template.tsx
+++ b/src/@narative/gatsby-theme-novela/templates/article.template.tsx
@@ -104,7 +104,7 @@ const Article: Template = ({ pageContext, location }) => {
                     <ArticleShare />
                 </MDXRenderer>
             </ArticleBody>
-            <div style={{ maxWidth: '680px', margin: '0 auto', marginBottom: '2rem' }}>
+            <div style={{ maxWidth: '680px', margin: '0 auto', marginBottom: '2rem', padding: '0 2rem' }}>
                 <Disqus config={disqusConfig} />
             </div>
             {mailchimp && article.subscription && <Subscription />}


### PR DESCRIPTION
# Before I add padding
<img width="384" alt="스크린샷 2019-12-27 오후 10 17 07" src="https://user-images.githubusercontent.com/25566139/71518682-59fce300-28f7-11ea-9f94-edc49c24e5c9.png">

# After I add padding
<img width="384" alt="스크린샷 2019-12-27 오후 10 23 11" src="https://user-images.githubusercontent.com/25566139/71518729-89abeb00-28f7-11ea-8334-5da8da93c3a9.png">

Isn't it much better than before?